### PR TITLE
Ignore env file for Docker setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.env
 credentials.ink
 *.json
 db/


### PR DESCRIPTION
As the alternative Docker setup for Lucerne requires a `.env `file, I thought it'll be good to add this to `gitignore`